### PR TITLE
Updating hugo version and removing undraft.

### DIFF
--- a/.docksal/commands/init
+++ b/.docksal/commands/init
@@ -34,13 +34,12 @@ fin exec "hugo new site . --force"
 
 # Create a test post
 fin exec hugo new posts/my-first-post.md
-fin exec hugo undraft content/posts/my-first-post.md
 fin exec 'echo -e "Hello, Hugo on Docksal!" >> "content/posts/my-first-post.md"'
 
 # Download a theme
 echo-green "Downloading a theme..."
 sleep 1
-fin exec git init 
+fin exec git init
 fin exec git submodule add https://github.com/budparr/gohugo-theme-ananke.git themes/ananke
 
 # Enable theme
@@ -48,7 +47,7 @@ echo 'theme = "ananke"' >> config.toml
 
 # Compile static site
 echo-green "Compiling a static site..."
-fin exec hugo --baseURL "${STATIC_URL}"
+fin exec hugo --baseURL "${STATIC_URL}" --buildDrafts
 
 # Done
 sleep 1

--- a/.docksal/services/cli/Dockerfile
+++ b/.docksal/services/cli/Dockerfile
@@ -1,5 +1,5 @@
 # Use a stock Docksal image as the base
-FROM docksal/cli:2.1-php7.1
+FROM docksal/cli:2.6-php7.3
 
 # Install hugo 0.34
 RUN wget -q https://github.com/gohugoio/hugo/releases/download/v0.59.0/hugo_0.59.0_Linux-64bit.deb -O /tmp/hugo.deb \

--- a/.docksal/services/cli/Dockerfile
+++ b/.docksal/services/cli/Dockerfile
@@ -2,5 +2,5 @@
 FROM docksal/cli:2.1-php7.1
 
 # Install hugo 0.34
-RUN wget -q https://github.com/gohugoio/hugo/releases/download/v0.34/hugo_0.34_Linux-64bit.deb -O /tmp/hugo.deb \
+RUN wget -q https://github.com/gohugoio/hugo/releases/download/v0.59.0/hugo_0.59.0_Linux-64bit.deb -O /tmp/hugo.deb \
     && dpkg -i /tmp/hugo.deb


### PR DESCRIPTION
The current version of Hugo listed in fin init does not download.  This updates to the most recent version, 0.59.0.

Since the version listed in `fin init` was released, there have been changes to remove the `undraft` command from build.  Instead, `fin init` will now build the site with the `--buildDrafts` flag.

Also updated the default image in the Dockerfile to 2.6-php7.3